### PR TITLE
エラーハンドリングを行う

### DIFF
--- a/YumemiInternTask.xcodeproj/project.pbxproj
+++ b/YumemiInternTask.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		8831862426DCA14300427B82 /* WeatherContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862326DCA14300427B82 /* WeatherContract.swift */; };
 		8831862626DCA31E00427B82 /* WeatherPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862526DCA31E00427B82 /* WeatherPresenter.swift */; };
 		8831862826DCA6EC00427B82 /* WeatherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862726DCA6EC00427B82 /* WeatherModel.swift */; };
+		8831862D26DCB77400427B82 /* YumemiWeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862C26DCB77400427B82 /* YumemiWeatherError.swift */; };
 		8831862B26DCAB3500427B82 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862A26DCAB3500427B82 /* Weather.swift */; };
 		8831863226DCD43600427B82 /* WeatherExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831863126DCD43600427B82 /* WeatherExtension.swift */; };
 /* End PBXBuildFile section */
@@ -60,6 +61,7 @@
 		8831862326DCA14300427B82 /* WeatherContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherContract.swift; sourceTree = "<group>"; };
 		8831862526DCA31E00427B82 /* WeatherPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherPresenter.swift; sourceTree = "<group>"; };
 		8831862726DCA6EC00427B82 /* WeatherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherModel.swift; sourceTree = "<group>"; };
+		8831862C26DCB77400427B82 /* YumemiWeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YumemiWeatherError.swift; sourceTree = "<group>"; };
 		8831862A26DCAB3500427B82 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		8831863126DCD43600427B82 /* WeatherExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -200,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				8831862A26DCAB3500427B82 /* Weather.swift */,
+				8831862C26DCB77400427B82 /* YumemiWeatherError.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 				8831861C26DC80CC00427B82 /* Colors.swift in Sources */,
 				8831862826DCA6EC00427B82 /* WeatherModel.swift in Sources */,
 				8831862B26DCAB3500427B82 /* Weather.swift in Sources */,
+				8831862D26DCB77400427B82 /* YumemiWeatherError.swift in Sources */,
 				8831862426DCA14300427B82 /* WeatherContract.swift in Sources */,
 				883185E626DC72D300427B82 /* AppDelegate.swift in Sources */,
 				883185E826DC72D300427B82 /* SceneDelegate.swift in Sources */,

--- a/YumemiInternTask.xcodeproj/project.pbxproj
+++ b/YumemiInternTask.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		8831862B26DCAB3500427B82 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862A26DCAB3500427B82 /* Weather.swift */; };
 		8831862D26DCB77400427B82 /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862C26DCB77400427B82 /* WeatherError.swift */; };
 		8831863226DCD43600427B82 /* WeatherExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831863126DCD43600427B82 /* WeatherExtension.swift */; };
+		8831863626DDF5D500427B82 /* WeatherErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831863526DDF5D500427B82 /* WeatherErrorExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +65,7 @@
 		8831862A26DCAB3500427B82 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		8831862C26DCB77400427B82 /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 		8831863126DCD43600427B82 /* WeatherExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherExtension.swift; sourceTree = "<group>"; };
+		8831863526DDF5D500427B82 /* WeatherErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherErrorExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -194,6 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				8831863126DCD43600427B82 /* WeatherExtension.swift */,
+				8831863526DDF5D500427B82 /* WeatherErrorExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				8831861C26DC80CC00427B82 /* Colors.swift in Sources */,
 				8831862826DCA6EC00427B82 /* WeatherModel.swift in Sources */,
 				8831862B26DCAB3500427B82 /* Weather.swift in Sources */,
+				8831863626DDF5D500427B82 /* WeatherErrorExtension.swift in Sources */,
 				8831862D26DCB77400427B82 /* WeatherError.swift in Sources */,
 				8831862426DCA14300427B82 /* WeatherContract.swift in Sources */,
 				883185E626DC72D300427B82 /* AppDelegate.swift in Sources */,

--- a/YumemiInternTask.xcodeproj/project.pbxproj
+++ b/YumemiInternTask.xcodeproj/project.pbxproj
@@ -20,8 +20,8 @@
 		8831862426DCA14300427B82 /* WeatherContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862326DCA14300427B82 /* WeatherContract.swift */; };
 		8831862626DCA31E00427B82 /* WeatherPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862526DCA31E00427B82 /* WeatherPresenter.swift */; };
 		8831862826DCA6EC00427B82 /* WeatherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862726DCA6EC00427B82 /* WeatherModel.swift */; };
-		8831862D26DCB77400427B82 /* YumemiWeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862C26DCB77400427B82 /* YumemiWeatherError.swift */; };
 		8831862B26DCAB3500427B82 /* Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862A26DCAB3500427B82 /* Weather.swift */; };
+		8831862D26DCB77400427B82 /* WeatherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831862C26DCB77400427B82 /* WeatherError.swift */; };
 		8831863226DCD43600427B82 /* WeatherExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8831863126DCD43600427B82 /* WeatherExtension.swift */; };
 /* End PBXBuildFile section */
 
@@ -61,8 +61,8 @@
 		8831862326DCA14300427B82 /* WeatherContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherContract.swift; sourceTree = "<group>"; };
 		8831862526DCA31E00427B82 /* WeatherPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherPresenter.swift; sourceTree = "<group>"; };
 		8831862726DCA6EC00427B82 /* WeatherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherModel.swift; sourceTree = "<group>"; };
-		8831862C26DCB77400427B82 /* YumemiWeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YumemiWeatherError.swift; sourceTree = "<group>"; };
 		8831862A26DCAB3500427B82 /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
+		8831862C26DCB77400427B82 /* WeatherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherError.swift; sourceTree = "<group>"; };
 		8831863126DCD43600427B82 /* WeatherExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -202,7 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				8831862A26DCAB3500427B82 /* Weather.swift */,
-				8831862C26DCB77400427B82 /* YumemiWeatherError.swift */,
+				8831862C26DCB77400427B82 /* WeatherError.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -370,7 +370,7 @@
 				8831861C26DC80CC00427B82 /* Colors.swift in Sources */,
 				8831862826DCA6EC00427B82 /* WeatherModel.swift in Sources */,
 				8831862B26DCAB3500427B82 /* Weather.swift in Sources */,
-				8831862D26DCB77400427B82 /* YumemiWeatherError.swift in Sources */,
+				8831862D26DCB77400427B82 /* WeatherError.swift in Sources */,
 				8831862426DCA14300427B82 /* WeatherContract.swift in Sources */,
 				883185E626DC72D300427B82 /* AppDelegate.swift in Sources */,
 				883185E826DC72D300427B82 /* SceneDelegate.swift in Sources */,

--- a/YumemiInternTask/Contract/WeatherContract.swift
+++ b/YumemiInternTask/Contract/WeatherContract.swift
@@ -8,8 +8,8 @@ protocol WeatherView: AnyObject {
     func showWeather(_ weather: Weather)
 
     /// エラーを表示させる
-    ///- parameter message:エラーメッセージ
-    func showError(message:String)
+    /// - parameter message:エラーメッセージ
+    func showError(message: String)
 }
 
 protocol WeatherPresentation: AnyObject {

--- a/YumemiInternTask/Contract/WeatherContract.swift
+++ b/YumemiInternTask/Contract/WeatherContract.swift
@@ -1,10 +1,15 @@
 import Foundation
 import UIKit
+import YumemiWeather
 
 protocol WeatherView: AnyObject {
     /// 天気画像を表示する
     /// - parameter weather:Weather型の天気情報
     func showWeather(_ weather: Weather)
+
+    /// エラーを表示させる
+    ///- parameter message:エラーメッセージ
+    func showError(message:String)
 }
 
 protocol WeatherPresentation: AnyObject {
@@ -16,6 +21,10 @@ protocol WeatherPresentationOutput: AnyObject {
     /// 取得した天気を出力する
     /// - parameter weatherString;天気を表す文字列
     func outputWeather(weatherString: String)
+
+    /// エラーを出力する
+    /// - parameter error:エラー
+    func outputWeatherError(error: YumemiWeatherError)
 }
 
 protocol WeatherModelProtocol: AnyObject {

--- a/YumemiInternTask/Contract/WeatherContract.swift
+++ b/YumemiInternTask/Contract/WeatherContract.swift
@@ -24,7 +24,7 @@ protocol WeatherPresentationOutput: AnyObject {
 
     /// エラーを出力する
     /// - parameter error:エラー
-    func outputWeatherError(error: YumemiWeatherError)
+    func outputWeatherError(error: WeatherError)
 }
 
 protocol WeatherModelProtocol: AnyObject {

--- a/YumemiInternTask/Contract/WeatherContract.swift
+++ b/YumemiInternTask/Contract/WeatherContract.swift
@@ -23,7 +23,7 @@ protocol WeatherPresentationOutput: AnyObject {
 
     /// エラーを出力する
     /// - parameter error:エラー
-    func outputWeatherError(with error: WeatherError)
+    func outputWeatherError(_ error: WeatherError)
 }
 
 protocol WeatherModelProtocol: AnyObject {

--- a/YumemiInternTask/Contract/WeatherContract.swift
+++ b/YumemiInternTask/Contract/WeatherContract.swift
@@ -8,7 +8,7 @@ protocol WeatherView: AnyObject {
 
     /// エラーを表示させる
     /// - parameter message:エラーメッセージ
-    func showError(message: String)
+    func showError(withMesssage message: String)
 }
 
 protocol WeatherPresentation: AnyObject {
@@ -23,7 +23,7 @@ protocol WeatherPresentationOutput: AnyObject {
 
     /// エラーを出力する
     /// - parameter error:エラー
-    func outputWeatherError(error: WeatherError)
+    func outputWeatherError(with error: WeatherError)
 }
 
 protocol WeatherModelProtocol: AnyObject {

--- a/YumemiInternTask/Contract/WeatherContract.swift
+++ b/YumemiInternTask/Contract/WeatherContract.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import YumemiWeather
 
 protocol WeatherView: AnyObject {
     /// 天気画像を表示する

--- a/YumemiInternTask/Data/WeatherError.swift
+++ b/YumemiInternTask/Data/WeatherError.swift
@@ -1,19 +1,7 @@
 import Foundation
 import UIKit
-import enum YumemiWeather.YumemiWeatherError
 
 enum WeatherError {
     case invalidParameterError
     case unknownError
-}
-
-extension WeatherError {
-    var errorMessage: String {
-        switch self {
-        case .invalidParameterError:
-            return "リクエストが不正です"
-        case .unknownError:
-            return "予期せぬエラーが発生しました"
-        }
-    }
 }

--- a/YumemiInternTask/Data/WeatherError.swift
+++ b/YumemiInternTask/Data/WeatherError.swift
@@ -1,14 +1,15 @@
 import Foundation
 import UIKit
+import enum YumemiWeather.YumemiWeatherError
 
-enum YumemiWeatherError {
+enum WeatherError {
     case invalidParameterError
     case unknownError
 }
 
-extension YumemiWeatherError{
-    var errorMessage:String{
-        switch self  {
+extension WeatherError {
+    var errorMessage: String {
+        switch self {
         case .invalidParameterError:
             return "リクエストが不正です"
         case .unknownError:

--- a/YumemiInternTask/Data/YumemiWeatherError.swift
+++ b/YumemiInternTask/Data/YumemiWeatherError.swift
@@ -1,0 +1,18 @@
+import Foundation
+import UIKit
+
+enum YumemiWeatherError {
+    case invalidParameterError
+    case unknownError
+}
+
+extension YumemiWeatherError{
+    var errorMessage:String{
+        switch self  {
+        case .invalidParameterError:
+            return "リクエストが不正です"
+        case .unknownError:
+            return "予期せぬエラーが発生しました"
+        }
+    }
+}

--- a/YumemiInternTask/Extension/WeatherErrorExtension.swift
+++ b/YumemiInternTask/Extension/WeatherErrorExtension.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension WeatherError {
+    var errorMessage: String {
+        switch self {
+        case .invalidParameterError:
+            return "リクエストが不正です"
+        case .unknownError:
+            return "予期せぬエラーが発生しました"
+        }
+    }
+}

--- a/YumemiInternTask/Model/WeatherModel.swift
+++ b/YumemiInternTask/Model/WeatherModel.swift
@@ -15,7 +15,15 @@ class WeatherModel: WeatherModelProtocol {
             let weatherString = try YumemiWeather.fetchWeather(at: "")
             output?.outputWeather(weatherString: weatherString)
         } catch let error as YumemiWeatherError {
-            output?.outputWeatherError(error: error)
+            var weatherError: WeatherError
+            switch error {
+            case .invalidParameterError:
+                weatherError = .invalidParameterError
+
+            case .unknownError:
+                weatherError = .unknownError
+            }
+            output?.outputWeatherError(error: weatherError)
         } catch {
             fatalError("unexpected error occured : \(error.localizedDescription)")
         }

--- a/YumemiInternTask/Model/WeatherModel.swift
+++ b/YumemiInternTask/Model/WeatherModel.swift
@@ -23,7 +23,7 @@ class WeatherModel: WeatherModelProtocol {
             case .unknownError:
                 weatherError = .unknownError
             }
-            output?.outputWeatherError(with: weatherError)
+            output?.outputWeatherError(weatherError)
         } catch {
             fatalError("unexpected error occured : \(error.localizedDescription)")
         }

--- a/YumemiInternTask/Model/WeatherModel.swift
+++ b/YumemiInternTask/Model/WeatherModel.swift
@@ -11,7 +11,13 @@ class WeatherModel: WeatherModelProtocol {
     // MARK: WeatherModelProtocol
 
     func fetchWeather() {
-        let weatherString = YumemiWeather.fetchWeather()
-        output?.outputWeather(weatherString: weatherString)
+        do {
+            let weatherString = try YumemiWeather.fetchWeather(at: "")
+            output?.outputWeather(weatherString: weatherString)
+        } catch let error as YumemiWeatherError {
+            output?.outputWeatherError(error: error)
+        } catch {
+            fatalError("unexpected error occured : \(error.localizedDescription)")
+        }
     }
 }

--- a/YumemiInternTask/Model/WeatherModel.swift
+++ b/YumemiInternTask/Model/WeatherModel.swift
@@ -15,7 +15,7 @@ class WeatherModel: WeatherModelProtocol {
             let weatherString = try YumemiWeather.fetchWeather(at: "")
             output?.outputWeather(weatherString: weatherString)
         } catch let error as YumemiWeatherError {
-            var weatherError: WeatherError
+            let weatherError: WeatherError
             switch error {
             case .invalidParameterError:
                 weatherError = .invalidParameterError
@@ -24,6 +24,7 @@ class WeatherModel: WeatherModelProtocol {
                 weatherError = .unknownError
             }
             output?.outputWeatherError(error: weatherError)
+            
         } catch {
             fatalError("unexpected error occured : \(error.localizedDescription)")
         }

--- a/YumemiInternTask/Model/WeatherModel.swift
+++ b/YumemiInternTask/Model/WeatherModel.swift
@@ -23,8 +23,7 @@ class WeatherModel: WeatherModelProtocol {
             case .unknownError:
                 weatherError = .unknownError
             }
-            output?.outputWeatherError(error: weatherError)
-            
+            output?.outputWeatherError(with: weatherError)
         } catch {
             fatalError("unexpected error occured : \(error.localizedDescription)")
         }

--- a/YumemiInternTask/Presenter/WeatherPresenter.swift
+++ b/YumemiInternTask/Presenter/WeatherPresenter.swift
@@ -1,5 +1,3 @@
-import enum YumemiWeather.YumemiWeatherError
-
 class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
     var view: WeatherView?
     var model: WeatherModelProtocol!
@@ -24,7 +22,7 @@ class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
         view?.showWeather(weather)
     }
 
-    func outputWeatherError(error: YumemiWeatherError) {
+    func outputWeatherError(error: WeatherError) {
         var message = ""
         switch error {
         case .invalidParameterError:

--- a/YumemiInternTask/Presenter/WeatherPresenter.swift
+++ b/YumemiInternTask/Presenter/WeatherPresenter.swift
@@ -22,7 +22,7 @@ class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
         view?.showWeather(weather)
     }
 
-    func outputWeatherError(error: WeatherError) {
-        view?.showError(message: error.errorMessage)
+    func outputWeatherError(with error: WeatherError) {
+        view?.showError(withMesssage: error.errorMessage)
     }
 }

--- a/YumemiInternTask/Presenter/WeatherPresenter.swift
+++ b/YumemiInternTask/Presenter/WeatherPresenter.swift
@@ -1,3 +1,5 @@
+import enum YumemiWeather.YumemiWeatherError
+
 class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
     var view: WeatherView?
     var model: WeatherModelProtocol!
@@ -20,5 +22,16 @@ class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
             fatalError("Unwxpected Weather String. YumemiWeather returned \(weatherString)")
         }
         view?.showWeather(weather)
+    }
+
+    func outputWeatherError(error: YumemiWeatherError) {
+        var message = ""
+        switch error {
+        case .invalidParameterError:
+            message = "不正なリクエストです"
+        case .unknownError:
+            message = "不明なエラーが発生しました"
+        }
+        view?.showError(message: message)
     }
 }

--- a/YumemiInternTask/Presenter/WeatherPresenter.swift
+++ b/YumemiInternTask/Presenter/WeatherPresenter.swift
@@ -22,7 +22,7 @@ class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
         view?.showWeather(weather)
     }
 
-    func outputWeatherError(with error: WeatherError) {
+    func outputWeatherError(_ error: WeatherError) {
         view?.showError(withMesssage: error.errorMessage)
     }
 }

--- a/YumemiInternTask/Presenter/WeatherPresenter.swift
+++ b/YumemiInternTask/Presenter/WeatherPresenter.swift
@@ -23,13 +23,6 @@ class WeatherPresenter: WeatherPresentation, WeatherPresentationOutput {
     }
 
     func outputWeatherError(error: WeatherError) {
-        var message = ""
-        switch error {
-        case .invalidParameterError:
-            message = "不正なリクエストです"
-        case .unknownError:
-            message = "不明なエラーが発生しました"
-        }
-        view?.showError(message: message)
+        view?.showError(message: error.errorMessage)
     }
 }

--- a/YumemiInternTask/View/WeatherViewController.swift
+++ b/YumemiInternTask/View/WeatherViewController.swift
@@ -17,7 +17,7 @@ class WeatherViewController: UIViewController, WeatherView {
         weatherImageView.tintColor = weather.color
     }
 
-    func showError(message: String) {
+    func showError(withMesssage message: String) {
         let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
         alert.addAction(.init(title: "OK", style: .default))
         present(alert, animated: true)

--- a/YumemiInternTask/View/WeatherViewController.swift
+++ b/YumemiInternTask/View/WeatherViewController.swift
@@ -17,6 +17,12 @@ class WeatherViewController: UIViewController, WeatherView {
         weatherImageView.tintColor = weather.color
     }
 
+    func showError(message: String) {
+        let alert = UIAlertController(title: "エラー", message: message, preferredStyle: .alert)
+        alert.addAction(.init(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
     // MARK: Private
 
     private let weatherImageView = UIImageView()


### PR DESCRIPTION
# やったこと
(このタスク)[https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md]の実装
Model層でエラーが発生した場合に、presentationOutputのエラーメソッドを呼ぶようにした

# 特にみて欲しいポイント
エラーハンドリングは適切に行われているかどうか
Modelでのエラーの振り分けが適切かどうか